### PR TITLE
Increment Taweret patch number for JOSS release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ Taweret = ["tests/samba_results.txt", "tests/bart_bmm_test_data/2d_*.txt"]
 
 [project]
 name = "Taweret"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
     { name="Kevin Ingles", email="kingles@illinois.edu"},
     { name="Dananjaya (Dan) Liyanage", email="liyanage@osu.edu"},


### PR DESCRIPTION
Release failed because `pyproject.toml` patch number had not been incremented.
Since we are instituting a "merge into main only" policy, this change has to be PR'd