### PR TITLE
Update upload-pages-artifact action to v4

### DIFF
--- a/.github/workflows/test_book.yml
+++ b/.github/workflows/test_book.yml
@@ -43,6 +43,6 @@ jobs:
         popd
 
     - name: Archive examples Jupyter book 
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: ${{ env.EXAMPLES_BOOK }}


### PR DESCRIPTION
Here's the failing test, I think. It seems that the upload-artifact:v3 is deprecated and has been removed in favour of v4 and higher. I am changing this to v4. 