### PR TITLE
changing the artifacts to new versions to fix build issue

### DIFF
--- a/.github/workflows/publish_book.yml
+++ b/.github/workflows/publish_book.yml
@@ -45,10 +45,10 @@ jobs:
         popd
 
     - name: Archive examples Jupyter book 
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v4
       with:
         path: ${{ env.EXAMPLES_BOOK }}
 
     - name: Publish Taweret Jupyter Book
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
I think I've finally caught the issue---deploy-pages v2 may also use old versions of upload-artifact, so I am changing it to v4. I also am changing upload-pages-artifact in case this is another issue. Interestingly the PR showed that the Jupyter Book built, but the merge and subsequent build of the Book failed. If this PR does not work, we can further diagnose it.