### PR TITLE
Adding the fix to release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           if   [ "${{ runner.os }}" == "Linux" ]; then
              sudo apt-get update
-             sudo apt-get -y install openmpi-bin
+             sudo apt-get -y install openmpi-bin libopenmpi-dev
           elif [ "${{ runner.os }}" == "macOS" ]; then
              /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
              brew install open-mpi


### PR DESCRIPTION
Added the `libopenmpi-dev` dependency to be installed when testing the building of the Taweret wheel. It is necessary for the `openbtmixing` dependency to correctly be built. 