### PR TITLE
changing macos and python tests to modern versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04,
-             macos-13, macos-14, macos-15]
+             macos-14, macos-15]
         mpi_impl: ["openmpi"]
         python-version: ["3.12"]
         miniconda-version: [py312_24.11.1-0]
         exclude:
           # Prebuilt Intel MPI package not available for macOS
-          - os: [macos-13, macos-14, macos-15]
+          - os: [macos-14, macos-15]
             mpi_impl: "impi_rt"
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/run_wheel_tests.yml
+++ b/.github/workflows/run_wheel_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         mpi_impl: ["openmpi", "mpich"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         exclude:
           # See similar tests for openbtmixing for more info.
           - os: ubuntu-24.04


### PR DESCRIPTION
Changing the macOS versions to only include 14 and 15, and changing Python versions from 3.9-3.13 to 3.10-3.13 since 3.9 is deprecated.