### PR TITLE
Remove print statements for model priors

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -7,12 +7,12 @@ chapters:
 
 - file: notebooks/LMM/LMM
   sections:
-  - file: notebooks/LMM/Linear_BMM_with_step_function_for_SAMBA_models
-  - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_SAMBA_models
-  - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models
-  - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models_Bilby_constrained_prior
+  # - file: notebooks/LMM/Linear_BMM_with_step_function_for_SAMBA_models
+  # - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_SAMBA_models
+  # - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models
+  # - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models_Bilby_constrained_prior
   - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_coleman_models
-  - file: notebooks/LMM/coleman_models_BMM_comparative_study
+  # - file: notebooks/LMM/coleman_models_BMM_comparative_study
 
 - file: notebooks/Biv_BMM/Bivariate_MM
   sections:

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -11,7 +11,7 @@ chapters:
   # - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_SAMBA_models
   # - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models
   # - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models_Bilby_constrained_prior
-  - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_coleman_models
+  # - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_coleman_models
   # - file: notebooks/LMM/coleman_models_BMM_comparative_study
 
 - file: notebooks/Biv_BMM/Bivariate_MM

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -5,8 +5,8 @@ options:
 chapters:
 - file: BMM_intro
 
-- file: notebooks/LMM/LMM
-  sections:
+# - file: notebooks/LMM/LMM
+#   sections:
   # - file: notebooks/LMM/Linear_BMM_with_step_function_for_SAMBA_models
   # - file: notebooks/LMM/Linear_BMM_with_cdf_function_for_SAMBA_models
   # - file: notebooks/LMM/Linear_BMM_with_switchcos_function_for_SAMBA_models

--- a/src/Taweret/models/coleman_models.py
+++ b/src/Taweret/models/coleman_models.py
@@ -28,7 +28,7 @@ class coleman_model_1(BaseModel):
 
         x = input_values.flatten()
         mean = np.zeros(len(x))
-        var = 0.3 * 0.3 * np.zeros(len(x))
+        var = 0.3 * 0.3 * np.ones(len(x))
 
         if len(model_param.flatten()) != 1:
             raise TypeError(
@@ -142,7 +142,7 @@ class coleman_model_2(BaseModel):
 
         x = input_values.flatten()
         mean = np.zeros(len(x))
-        var = 0.3 * 0.3 * np.zeros(len(x))
+        var = 0.3 * 0.3 * np.ones(len(x))
 
         if len(model_param.flatten()) != 1:
             raise TypeError(

--- a/src/Taweret/models/coleman_models.py
+++ b/src/Taweret/models/coleman_models.py
@@ -98,12 +98,10 @@ class coleman_model_1(BaseModel):
         Set the prior on model parameters.
         '''
         if bilby_priors is None:
-            # print('Using default priors for model 1')
             priors = bilby.prior.PriorDict()
             priors['model1_0'] = bilby.core.prior.Uniform(1, 6, "model1_0")
         else:
             priors = bilby_priors
-      #  print(priors)
         self._prior = priors
         return priors
 
@@ -212,12 +210,10 @@ class coleman_model_2(BaseModel):
         Set the prior on model parameters.
         '''
         if bilby_priors is None:
-            #print('Using default priors for model 2')
             priors = bilby.prior.PriorDict()
             priors['model2_0'] = bilby.core.prior.Uniform(-2, 3, "model2_0")
         else:
             priors = bilby_priors
-       # print(priors)
         self._prior = priors
         return priors
 

--- a/src/Taweret/models/coleman_models.py
+++ b/src/Taweret/models/coleman_models.py
@@ -98,12 +98,12 @@ class coleman_model_1(BaseModel):
         Set the prior on model parameters.
         '''
         if bilby_priors is None:
-            print('Using default priors for model 1')
+            # print('Using default priors for model 1')
             priors = bilby.prior.PriorDict()
             priors['model1_0'] = bilby.core.prior.Uniform(1, 6, "model1_0")
         else:
             priors = bilby_priors
-        print(priors)
+      #  print(priors)
         self._prior = priors
         return priors
 
@@ -212,12 +212,12 @@ class coleman_model_2(BaseModel):
         Set the prior on model parameters.
         '''
         if bilby_priors is None:
-            print('Using default priors for model 2')
+            #print('Using default priors for model 2')
             priors = bilby.prior.PriorDict()
             priors['model2_0'] = bilby.core.prior.Uniform(-2, 3, "model2_0")
         else:
             priors = bilby_priors
-        print(priors)
+       # print(priors)
         self._prior = priors
         return priors
 


### PR DESCRIPTION
Commented out print statements for default priors, and will be adding more commit statements on this branch soon to fix the notebooks that need to be commented out on the build TOC for the Jupyter Book. 