### PR TITLE
Enable automatic version updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  #
+  # Workflow files stored in the default location of `.github/workflows`,
+  # which are found automatically with directory set to "/"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should have been made directly on `main` since changes to `dependabot.yml` don't have any effect unless they occur on the default branch.