### PR TITLE
Update anaconda action

### DIFF
--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -16,10 +16,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04,
-             macos-14, macos-15]
+             macos-14, macos-15, macos-26, macos-26-intel]
         mpi_impl: ["openmpi"]
         python-version: ["3.12"]
-        miniconda-version: [py312_24.11.1-0]
         exclude:
           # Prebuilt Intel MPI package not available for macOS
           - os: [macos-14, macos-15]
@@ -30,7 +29,7 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v4.0.1
         with:
-          miniconda-version: ${{ matrix.miniconda-version }}
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
       - name: Checkout Taweret

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04,
              macos-14, macos-15, macos-26, macos-26-intel]
         mpi_impl: ["openmpi"]
-        python-version: ["3.12"]
+        python-version: ["3.14"]
         exclude:
           # Prebuilt Intel MPI package not available for macOS
           - os: [macos-14, macos-15]

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -10,9 +10,6 @@ jobs:
     #####----- RUN FULL TEST SUITE WITHOUT COVERAGE
     # Test through actual installations for end-to-end testing including
     # packaging.
-    #
-    # Refer to Issue #122 to understand use of older Python, older miniconda
-    # version, and older setup-miniconda version.
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04,
@@ -55,8 +52,6 @@ jobs:
         run: |
           python -m pip install openmpi
           conda list
-          #ls /Users/runner/miniconda3/envs/test/bin
-          #find /Users/runner/miniconda3 -name mpicxx
           which mpicxx || echo "Cannot find the MPI installation"
           mpicxx -show || echo "Cannot check the MPI wrapper specification"
       - name: Run tests without coverage

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -44,8 +44,8 @@ jobs:
         shell: bash -el {0}
         run: |
           which python
-          which pip
           python --version
+          python -m pip install --upgrade pip
           python -m pip install build
           conda info
           conda list

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -30,8 +30,9 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniconda-version: "latest"
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          conda-remove-defaults: true
       - name: Checkout Taweret
         uses: actions/checkout@v6
       - name: Setup miniconda & log
@@ -49,7 +50,6 @@ jobs:
         run: |
           python -m pip install openmpi
           conda list
-          python -m pip list
           #ls /Users/runner/miniconda3/envs/test/bin
           #find /Users/runner/miniconda3 -name mpicxx
           which mpicxx || echo "Cannot find the MPI installation"

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -44,11 +44,12 @@ jobs:
           conda info
           conda list
           python -m pip list
-      - name: Install prebuilt ${{ matrix.mpi_impl }} via conda
+      - name: Install prebuilt ${{ matrix.mpi_impl }} via PyPI
         shell: bash -el {0}
         run: |
-          conda install -c conda-forge ${{ matrix.mpi_impl }}
+          python -m pip install openmpi
           conda list
+          python -m pip list
           #ls /Users/runner/miniconda3/envs/test/bin
           #find /Users/runner/miniconda3 -name mpicxx
           which mpicxx || echo "Cannot find the MPI installation"

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -27,11 +27,16 @@ jobs:
     env:
       CLONE_PATH: ${{ github.workspace }}
     steps:
+      # Following GH action messages, we explicitly remove the defaults channels
+      # setting.  According to the setup-miniconda docs, this is related to a
+      # workaround for
+      #            https://github.com/conda/conda/issues/12356
       - uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true
+          channels: conda-forge
           conda-remove-defaults: true
       - name: Checkout Taweret
         uses: actions/checkout@v6

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -45,11 +45,11 @@ jobs:
         run: |
           which python
           python --version
-          python -m pip install --upgrade pip
-          python -m pip install build
           conda info
           conda list
-          python -m pip list
+          conda install pip
+          python -m pip install build
+          conda list
       - name: Install prebuilt ${{ matrix.mpi_impl }} via PyPI
         shell: bash -el {0}
         run: |

--- a/.github/workflows/run_anaconda_tests.yml
+++ b/.github/workflows/run_anaconda_tests.yml
@@ -14,12 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04,
              macos-14, macos-15, macos-26, macos-26-intel]
-        mpi_impl: ["openmpi"]
         python-version: ["3.14"]
-        exclude:
-          # Prebuilt Intel MPI package not available for macOS
-          - os: [macos-14, macos-15]
-            mpi_impl: "impi_rt"
     runs-on: ${{ matrix.os }}
     env:
       CLONE_PATH: ${{ github.workspace }}
@@ -47,7 +42,7 @@ jobs:
           conda install pip
           python -m pip install build
           conda list
-      - name: Install prebuilt ${{ matrix.mpi_impl }} via PyPI
+      - name: Install prebuilt Open MPI via PyPI
         shell: bash -el {0}
         run: |
           python -m pip install openmpi

--- a/.github/workflows/run_wheel_tests.yml
+++ b/.github/workflows/run_wheel_tests.yml
@@ -10,6 +10,11 @@ jobs:
     #####----- RUN FULL TEST SUITE WITHOUT COVERAGE
     # Test through actual installations for end-to-end testing including
     # packaging.
+    #
+    # Since this is the main test action with many different test setups, we
+    # install different MPI implementations via OS package managers.  The
+    # "oldest" action confirms that users can install MPI implementations using
+    # PyPI/pip.
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26, macos-26-intel]

--- a/.github/workflows/test_oldest.yml
+++ b/.github/workflows/test_oldest.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26, macos-26-intel]
-        mpi_impl: ["openmpi"]
+        mpi_impl: ["openmpi", "mpich"]
         python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,6 +32,8 @@ jobs:
         run: |
           if   [ "${{ matrix.mpi_impl }}" = "openmpi" ]; then
              python -m pip install openmpi
+          elif [ "${{ matrix.mpi_impl }}" = "mpich" ]; then
+             python -m pip install mpich
           else
              echo "Cannot install ${{ matrix.mpi_impl }}"
              exit 1

--- a/.github/workflows/test_oldest.yml
+++ b/.github/workflows/test_oldest.yml
@@ -8,16 +8,16 @@ on:
     branches: [main]
 
 jobs:
-  # The mutual compatibility of Python and the external Python packages tested
-  # here are unrelated to the MPI implementation used with OpenBTMixing.
-  # Therefore, we only need to test with a single MPI implementation.
-  #
   # Python version should be maintained consistent with value in pyproject.toml,
   # tox.ini, etc.
+  #
+  # Since the main test action is installing MPI implementations manually using
+  # OS package managers, we have this action install MPI via PyPI/pip.
   tests:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26, macos-26-intel]
+        mpi_impl: ["openmpi"]
         python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -26,17 +26,17 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Open-MPI
-        run: |
-          if   [ "${{ runner.os }}" = "Linux" ]; then
-             sudo apt-get update
-             sudo apt-get -y install openmpi-bin libopenmpi-dev
-          elif [ "${{ runner.os }}" = "macOS" ]; then
-             brew update
-             brew install open-mpi
-          fi
       - name: Setup base Python environment
         run: $CLONE_PATH/.github/workflows/setup_base_python.sh ${{ runner.os }}
+      - name: Install ${{ matrix.mpi_impl }}
+        run: |
+          if   [ "${{ matrix.mpi_impl }}" = "openmpi" ]; then
+             python -m pip install openmpi
+          else
+             echo "Cannot install ${{ matrix.mpi_impl }}"
+             exit 1
+          fi
+          python -m pip list
       - name: Run tests
         run: |
           which mpirun || echo "Cannot find the MPI installation"

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -62,9 +62,7 @@ Taweret is available via pip install
 
     pip install Taweret
 
-If you prefer to use conda to setup your Python environment, you can still pip install Taweret, but be sure to `conda install pip` first, so you conda environment knows where to look.
-
-Alternative Installation
+Clone-based Installation
 ------------------------
 .. _repository: https://github.com/bandframework/Taweret.git
 
@@ -74,6 +72,20 @@ Python environment in developer or editable mode from the clone by running
 .. code-block:: bash
 
    pip install -e .
+
+Conda Installation
+------------------
+..
+    Ideally text such as this would be added to the OpenBTMixing docs and this
+    section would point users to that documentation to assess how best to
+    proceed with a Conda installation.
+
+While our set of GitHub actions currently test Anaconda installations, the setup
+of those tests within the action runner is less than desirable.  In particular,
+the action no longer succeeds to build OpenBTMixing if an MPI implementation is
+installed using Conda.  Rather, the action installs an MPI implementation from
+PyPI using ``pip``, which is less clean than a Conda installation.  Users who
+prefer to use Conda should proceed with extra caution.
 
 Testing
 -------


### PR DESCRIPTION
Pending tasks

- [x] Install each of MPICH and Open MPI (done!) from PyPI with pip into a clean, dedicated venv.
   - [x] Review installation of MPI in venv
   - [x] Activate and see that `mpirun` and `mpicxx` are found with `which`
   - [x] Check output of `mpicxx -show`
   - [x] Deactivate venv and confirm that `mpirun` and `mpicxx` are no longer found with `which`
   - [x] Try to build OpenBTMixing with MPI venv deactivated and confirm meson build failure
   - [x] Build OpenBTMixing with MPI venv activated and check command line tools with `otool -L` (and `-l` to check `LC_RPATH`)
   - [x] Run OpenBTMixing test in Python and see it pass
   - [x] Repeat above with Taweret and automatic build/install of openbtmixing.  Use clean venvs and also run OpenBTMixing test suite from the new venv just for kicks.
      * Remember to purge pip's cache prior to installing Taweret to get clean OpenBTMixing build/install
   - [x] Run OpenBTMixing `nocoverage` task with MPI venv deactivated and see it fail
   - [x] Run OpenBTMixing `nocoverage` task with MPI venv activated, confirm that it passes, review task's venv, check CLI with `otool` (`LC_RPATH` points to `lib` in MPI venv's folder)
   - [x] Repeat above with Taweret's `nocoverage` task (won't see meson log or MPI installation in the task's venv folder).
      * Probably best to clear cache here as well

PR Self-review

- [x] Review all changes
- [x] Review updated User Doc content as rendered by RTD in this PR
- [x] Spot check logs of altered actions and confirm expected setup and execution
- [x] Confirm all actions passing